### PR TITLE
fix: outputs handle and reference

### DIFF
--- a/.github/workflows/liberation.yml
+++ b/.github/workflows/liberation.yml
@@ -19,7 +19,7 @@ jobs:
   call-release-workflow:
     uses: mauroalderete/workflows/.github/workflows/release.yml@v0
     with:
-      next: ${{ jobs.call-versioning-workflow.outputs.next-patch }}
+      next: ${{ needs.call-versioning-workflow.outputs.next-patch }}
       include-artifacts: false
     secrets:
       github-token: ${{ secrets.GH_PROJECT_AUTOMATION || secrets.github-token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -93,5 +93,5 @@ jobs:
           git push --tag --force
 
           # output major and minor tags
-          echo "::set-output name=major::$major"
-          echo "::set-output name=minor::$minor"
+          echo "major=$major" >> $GITHUB_OUTPUT
+          echo "minor=$minor" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve the handling of outputs and dependencies between jobs.

Workflow improvements:

* [`.github/workflows/liberation.yml`](diffhunk://#diff-5516e34161002902c27d6181f22f978744a7b6ac7dcf677692d37818640e1fc3L22-R22): Changed the reference from `jobs.call-versioning-workflow.outputs.next-patch` to `needs.call-versioning-workflow.outputs.next-patch` to correctly handle job dependencies.
* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L96-R97): Updated the method for setting outputs from `::set-output` to appending to `$GITHUB_OUTPUT` to align with the latest GitHub Actions syntax.