### PR TITLE
5 as a consumer i want split versioning of release so that build artifacts before tag

### DIFF
--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -164,7 +164,8 @@ jobs:
     name: Assign and test labels from conventional-commits
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      pull-requests: write      
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/liberation.yml
+++ b/.github/workflows/liberation.yml
@@ -17,6 +17,8 @@ jobs:
       github-token: ${{ secrets.GH_PROJECT_AUTOMATION || secrets.github-token || secrets.GITHUB_TOKEN }}
 
   call-release-workflow:
+    permissions:
+      contents: write
     uses: mauroalderete/workflows/.github/workflows/release.yml@v0
     with:
       next: ${{ needs.call-versioning-workflow.outputs.next-patch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
-      statuses: write
     steps:
       - name: Set up repository
         uses: actions/checkout@v4

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -48,10 +48,6 @@ jobs:
   versioning:
     name: Versioning
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      statuses: write
     outputs:
       current: ${{ steps.semver.outputs.current }}
       next-patch: ${{ steps.semver.outputs.next }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to adjust permissions for various jobs. The most important changes involve modifying the `liberation.yml`, `release.yml`, and `versioning.yml` workflows to streamline permissions.

Adjustments to permissions in workflows:

* [`.github/workflows/liberation.yml`](diffhunk://#diff-5516e34161002902c27d6181f22f978744a7b6ac7dcf677692d37818640e1fc3R20-R21): Added `contents: write` permission for the `call-release-workflow` job.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-L32): Removed `pull-requests: write` and `statuses: write` permissions.
* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L51-L54): Removed `contents: write`, `pull-requests: write`, and `statuses: write` permissions.