### PR TITLE
fix: git push tag require content write permissions

### DIFF
--- a/.github/workflows/liberation.yml
+++ b/.github/workflows/liberation.yml
@@ -10,6 +10,9 @@ on:
         description: 'The Github token'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   call-versioning-workflow:
     uses: mauroalderete/workflows/.github/workflows/versioning.yml@v0
@@ -18,8 +21,6 @@ jobs:
 
   call-release-workflow:
     needs: call-versioning-workflow
-    permissions:
-      contents: write
     uses: mauroalderete/workflows/.github/workflows/release.yml@v0
     with:
       next: ${{ needs.call-versioning-workflow.outputs.next-patch }}

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -48,6 +48,8 @@ jobs:
   versioning:
     name: Versioning
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       current: ${{ steps.semver.outputs.current }}
       next-patch: ${{ steps.semver.outputs.next }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to adjust permissions settings for better security and functionality.

Changes to permissions settings:

* [`.github/workflows/liberation.yml`](diffhunk://#diff-5516e34161002902c27d6181f22f978744a7b6ac7dcf677692d37818640e1fc3R13-R15): Added `permissions` block with `contents: write` to the main workflow.
* [`.github/workflows/liberation.yml`](diffhunk://#diff-5516e34161002902c27d6181f22f978744a7b6ac7dcf677692d37818640e1fc3L21-L22): Removed redundant `permissions` block from the `call-release-workflow` job.
* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68R51-R52): Added `permissions` block with `contents: write` to the `versioning` job.